### PR TITLE
Fix State Map Snapshot and Offset

### DIFF
--- a/src/components/data_components/StateMap/StateMap.vue
+++ b/src/components/data_components/StateMap/StateMap.vue
@@ -568,7 +568,14 @@ export default mixins(WindowMixin, LoadingMixin).extend({
         },
         generateLayout(){
             const cy = (this as any).cy;
+            this.forceRedraw();
             cy.layout(this.graph_layout).run();
+        },
+        forceRedraw() {
+            const el = this.$refs.container as HTMLElement;
+            const display = el.style.display;
+            el.style.display = 'none';
+            el.style.display = display;
         }
     },
 });


### PR DESCRIPTION
# Overview
This PR fixes the snapshot issues we've been experiencing on various high DPI displays. The following displays were tested:
- Macbook Air (4k Retina)
- iMac (5k Retina)
- Windows desktop (2k and 4k monitors)
- Windows laptop (2k HDR)
- Windows desktop 1080p

This PR also addresses the issues with click ability when the state map is moved. By forcing a re-render, the state map updates to the right location after it has been translated in the x and y direction.

Addresses #97. 