### PR TITLE
Do not draw title if undefined or null

### DIFF
--- a/src/components/Core/SnapshotHelper.ts
+++ b/src/components/Core/SnapshotHelper.ts
@@ -193,11 +193,13 @@ export function composite_images(images: SubImage[], opts: SnapshotOptions): Pro
                         item.pos_x * opts.scale, item.pos_y * opts.scale,
                         img.width, img.height);
                 }
-                ctx.save();
-                ctx.font = `bold ${16 * opts.scale}px Verdana,Arial,sans-serif`;
-                ctx.textBaseline = 'bottom';
-                ctx.fillText(item.title, item.pos_x * opts.scale, item.pos_y * opts.scale);
-                ctx.restore();
+                if (item.title !== undefined && item.title !== null) {
+                    ctx.save();
+                    ctx.font = `bold ${16 * opts.scale}px Verdana,Arial,sans-serif`;
+                    ctx.textBaseline = 'bottom';
+                    ctx.fillText(item.title, item.pos_x * opts.scale, item.pos_y * opts.scale);
+                    ctx.restore();
+                }
                 resolve();
             };
             img.src = item.dataURI as string;


### PR DESCRIPTION
Fix an issue where composed snapshots erroneously draw a snapshot title when the title is `undefined` or `null`.