### PR TITLE
Notification & Toasts 

### DIFF
--- a/src/renderer/components/Core/IO/Toasts.ts
+++ b/src/renderer/components/Core/IO/Toasts.ts
@@ -18,7 +18,7 @@ export function showSaveSuccessToast(dest: string, noun: string, showOrOpen: 'op
                 h('a', {
                     href: 'javascript:void(0);',
                     title: `Click to ${showOrOpen}`,
-                    click: clickHandler,
+                    onClick: clickHandler,
                 }, dest),
             ]);
 
@@ -30,7 +30,11 @@ export function showSaveSuccessToast(dest: string, noun: string, showOrOpen: 'op
             default: body
         },
     });
-    useHistoryStore().addEntry({message: body, variant: 'success'});
+    useHistoryStore().addEntry({
+        message: body,
+        variant: 'success',
+        details: noun,
+    });
 }
 
 

--- a/src/renderer/components/HistoryViewer.vue
+++ b/src/renderer/components/HistoryViewer.vue
@@ -6,7 +6,13 @@
                 <template #title>
                     <timeago :datetime="itm.time" />
                 </template>
-                {{ itm.message }}
+                <component
+                :is="resolveMessage(itm.message)"
+                v-if="isVNode(itm.message)"
+                />
+                <div v-else>
+                    {{ itm.message }}
+                </div>
                 <BLink v-if="itm.details" href="#" @click.prevent="toggleDetails(idx)" class="details-link">
                     {{ itm.showDetails ? "Hide Details" : "Show Details" }}
                 </BLink>
@@ -26,6 +32,7 @@
 <script lang="ts">
 import { defineComponent, computed, ref } from "vue";
 import { useHistoryStore } from "@store/history.store";
+import { h } from 'vue';
 
 export default defineComponent({
     setup() {
@@ -60,13 +67,25 @@ export default defineComponent({
             items.value[idx].showDetails = !items.value[idx].showDetails;
             console.log("New state:", items.value[idx].showDetails);
         };
-
+        
+        const isVNode = (msg) => typeof msg === 'function';
+        
+        const resolveMessage = (msgFn) => {
+            try {
+                return { render: msgFn };
+            } catch (e) {
+                return { render: () => h('span', 'Error rendering message') };
+            }
+        };
+        
         const removeNotification = (idx) => {
             historyStore.removeEntry(idx); 
         };
 
         return {
             items,
+            isVNode,
+            resolveMessage,
             toggleDetails,
             removeNotification,
         };


### PR DESCRIPTION
Enabled toast notifications to render saved file paths as clickable links that correctly open the file using Electron's shell API.

Updated the notification history viewer to support displaying saved snapshot paths as interactive links and Non-link messages like file load notifications continue to render as plain text for clarity.